### PR TITLE
✨ Feat: 킥보드 상세 정보 UI

### DIFF
--- a/SSENG/View/MapView/MapViewController.swift
+++ b/SSENG/View/MapView/MapViewController.swift
@@ -126,7 +126,7 @@ class MapViewController: UIViewController {
     $0.isUserInteractionEnabled = true
   }
 
-  private let rideingButton = UIButton().then {
+  private let riddingButton = UIButton().then {
     $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .bold)
     $0.setTitleColor(.white, for: .normal)
     $0.setTitle("대여하기", for: .normal)
@@ -171,7 +171,7 @@ class MapViewController: UIViewController {
   private func setupUI() {
     [mapView, controlStackView, myPageButton, rideKickBoardView].forEach { view.addSubview($0) }
     [reloadButton, dividerView, locationButton].forEach { controlStackView.addArrangedSubview($0) }
-    [kickBoardHStackView, rideingButton].forEach { rideKickBoardView.addSubview($0) }
+    [kickBoardHStackView, riddingButton].forEach { rideKickBoardView.addSubview($0) }
     [typeImageView, kickBoardVStackView].forEach { kickBoardHStackView.addArrangedSubview($0) }
     [batteryLabel, priceLabel, detailLocationTitleLabel, detailLocationLabel].forEach { kickBoardVStackView.addArrangedSubview($0) }
   }
@@ -224,7 +224,7 @@ class MapViewController: UIViewController {
       $0.leading.top.trailing.equalToSuperview().inset(20)
     }
 
-    rideingButton.snp.makeConstraints {
+    riddingButton.snp.makeConstraints {
       $0.top.equalTo(kickBoardHStackView.snp.bottom).offset(20)
       $0.leading.trailing.equalToSuperview().inset(20)
     }

--- a/SSENG/View/MapView/MapViewController.swift
+++ b/SSENG/View/MapView/MapViewController.swift
@@ -83,6 +83,59 @@ class MapViewController: UIViewController {
     $0.layer.shadowRadius = 6
   }
 
+  private let kickBoardHStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.distribution = .fillEqually
+    $0.alignment = .center
+    $0.spacing = 15
+  }
+
+  private let kickBoardVStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.distribution = .fillEqually
+    $0.spacing = 8
+  }
+
+  // 타입별 이미지
+  private let typeImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+  }
+
+  // 배터리
+  private let batteryLabel = UILabel().then {
+    $0.textColor = .black
+    $0.font = .systemFont(ofSize: 12, weight: .bold)
+  }
+
+  // 가격
+  private let priceLabel = UILabel().then {
+    $0.textColor = .black
+    $0.font = .systemFont(ofSize: 12, weight: .bold)
+  }
+
+  // 상세위치
+  private let detailLocationTitleLabel = UILabel().then {
+    $0.textColor = .black
+    $0.text = "- 상세 위치 -"
+    $0.font = .systemFont(ofSize: 12, weight: .bold)
+  }
+
+  private let detailLocationLabel = UILabel().then {
+    $0.textColor = .black
+    $0.font = .systemFont(ofSize: 12)
+    $0.isUserInteractionEnabled = true
+  }
+
+  private let rideingButton = UIButton().then {
+    $0.titleLabel?.font = .systemFont(ofSize: 18, weight: .bold)
+    $0.setTitleColor(.white, for: .normal)
+    $0.setTitle("대여하기", for: .normal)
+    $0.layer.cornerRadius = 8
+    $0.backgroundColor = .main
+    $0.layer.borderWidth = 1
+    $0.layer.borderColor = UIColor.black.cgColor
+  }
+
   var rideKickBoardViewShowConstraint: [Constraint] = []
   var rideKickBoardViewHiddenConstraint: [Constraint] = []
   var controlStackViewConstraint: [Constraint] = []
@@ -98,6 +151,7 @@ class MapViewController: UIViewController {
     setupConstraints()
     setupButtonActions()
     allKickBoardMarker()
+
     locationManager.requestWhenInUseAuthorization()
   }
 
@@ -117,6 +171,9 @@ class MapViewController: UIViewController {
   private func setupUI() {
     [mapView, controlStackView, myPageButton, rideKickBoardView].forEach { view.addSubview($0) }
     [reloadButton, dividerView, locationButton].forEach { controlStackView.addArrangedSubview($0) }
+    [kickBoardHStackView, rideingButton].forEach { rideKickBoardView.addSubview($0) }
+    [typeImageView, kickBoardVStackView].forEach { kickBoardHStackView.addArrangedSubview($0) }
+    [batteryLabel, priceLabel, detailLocationTitleLabel, detailLocationLabel].forEach { kickBoardVStackView.addArrangedSubview($0) }
   }
 
   // 제약조건
@@ -143,9 +200,13 @@ class MapViewController: UIViewController {
       $0.size.equalTo(50)
     }
 
+    typeImageView.snp.makeConstraints {
+      $0.height.equalTo(80)
+    }
+
     rideKickBoardView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview()
-      $0.height.equalTo(200)
+      $0.height.equalToSuperview().multipliedBy(0.25)
     }
 
     rideKickBoardViewShowConstraint = rideKickBoardView.snp.prepareConstraints {
@@ -158,10 +219,19 @@ class MapViewController: UIViewController {
     for constraint in rideKickBoardViewHiddenConstraint {
       constraint.isActive = true
     }
+
+    kickBoardHStackView.snp.makeConstraints {
+      $0.leading.top.trailing.equalToSuperview().inset(20)
+    }
+
+    rideingButton.snp.makeConstraints {
+      $0.top.equalTo(kickBoardHStackView.snp.bottom).offset(20)
+      $0.leading.trailing.equalToSuperview().inset(20)
+    }
   }
 
   // 킥보드 정보창 띄우기
-  private func showKickBoardView() {
+  private func showKickBoardView(kickBoard: Kickboard) {
     for constraint in rideKickBoardViewHiddenConstraint {
       constraint.isActive = false
     }
@@ -171,7 +241,18 @@ class MapViewController: UIViewController {
     UIView.animate(withDuration: 0.3) {
       self.view.layoutIfNeeded()
     }
+
     print("마커 클릭됨!")
+
+    if kickBoard.type == 1 {
+      typeImageView.image = UIImage(resource: .kickboard)
+      priceLabel.text = "분당: 100원"
+    } else {
+      typeImageView.image = UIImage(resource: .bike)
+      priceLabel.text = "분당: 1000원"
+    }
+    batteryLabel.attributedText = batteryStatusAttributedText(for: Int(kickBoard.battery))
+    detailLocationLabel.text = "\(kickBoard.detailLocation ?? "정보 없음")"
   }
 
   // 킥보드정보 창 가리기
@@ -237,17 +318,36 @@ class MapViewController: UIViewController {
         marker.iconImage = NMFOverlayImage(image: image)
       }
     }
-    marker.iconTintColor = .black
+
+    marker.userInfo = ["kickboard": kickboard]
     marker.isForceShowIcon = true
     marker.width = 42.5
     marker.height = 42.5
     marker.captionOffset = 8
     marker.mapView = mapView
     marker.touchHandler = { [weak self] _ in
-      self?.showKickBoardView()
+      self?.showKickBoardView(kickBoard: kickboard)
       return true
     }
     kickboardMarkers.append(marker)
+  }
+
+  // 배터리 상태에 따라 아이콘과 텍스트를 반환하는 메서드
+  private func batteryStatusAttributedText(for batteryLevel: Int) -> NSAttributedString {
+    let imageAttachment = NSTextAttachment()
+    if batteryLevel == 100 {
+      imageAttachment.image = UIImage(systemName: "battery.100percent")
+    } else if batteryLevel >= 51 {
+      imageAttachment.image = UIImage(systemName: "battery.75percent")
+    } else if batteryLevel >= 26 {
+      imageAttachment.image = UIImage(systemName: "battery.50percent")
+    } else {
+      imageAttachment.image = UIImage(systemName: "battery.25percent")
+    }
+
+    let fullString = NSMutableAttributedString(attachment: imageAttachment)
+    fullString.append(NSAttributedString(string: " \(batteryLevel)%"))
+    return fullString
   }
 
   // MARK: - Action
@@ -256,6 +356,9 @@ class MapViewController: UIViewController {
     myPageButton.addTarget(self, action: #selector(didTabMyPageButton), for: .touchUpInside)
     reloadButton.addTarget(self, action: #selector(didTabReloadButton), for: .touchUpInside)
     locationButton.addTarget(self, action: #selector(didTapLocationButton), for: .touchUpInside)
+//    rideingButton.addTarget(self, action: #selector(didTapRideingButton), for: .touchUpInside)
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleDetailLocationLabelTap))
+    detailLocationLabel.addGestureRecognizer(tapGesture)
   }
 
   // 마이페이지 버튼 액션
@@ -274,6 +377,17 @@ class MapViewController: UIViewController {
   @objc private func didTapLocationButton() {
     print("Location Tapped")
     locationManager.startUpdatingLocation()
+  }
+
+  // 상세위치 탭 제스처 액션
+  @objc private func handleDetailLocationLabelTap() {
+    let alert = UIAlertController(
+      title: "상세 위치",
+      message: detailLocationLabel.text,
+      preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "확인", style: .default))
+    present(alert, animated: true)
   }
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- #28 

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 킥보드 마커 클릭시 킥보드 정보 띄우기
- 킥보드 정보에는 배터리 잔량, 가격, 상세 위치 표시
- 배터리 잔량에는 100% 일경우 꽉찬 이미지,51% ~ 99% 일 경우 1/3깍여있는 이미지, 26%~ 50%일 경우 절반이 깍여있는 이미지, 25% 이하일 경우 1/3이 남아있는 이미지를 표시
- 상세위치 텍스트가 길어서 잘릴 수도 있기에 텍스트 라벨을 클릭시 알림창으로 상세위치 전부 표시 하였습니다.   
- 또한 화면이 작은 SE2에서도 잘 나올 수 있도록 제약조건을 수정하였습니다.
 
## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

<img width="483" height="911" alt="스크린샷 2025-07-18 02 56 30" src="https://github.com/user-attachments/assets/8a290e80-a176-4aa1-91f8-c80b49dd2062" />

<img width="450" height="892" alt="스크린샷 2025-07-18 02 56 49" src="https://github.com/user-attachments/assets/b5d54e41-e556-40e2-9cd0-2af55832b6bc" />

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.
