### PR TITLE
🚀 Perf: 카메라 시야 내에있는 마커만 화면에 렌더링하기

### DIFF
--- a/SSENG/View/MapView/MapViewController.swift
+++ b/SSENG/View/MapView/MapViewController.swift
@@ -506,13 +506,30 @@ extension MapViewController {
       marker.mapView = nil
     }
 
+    let visibleBounds = mapView.contentBounds
+
     switch selected {
     case .all:
-      allMarkers.forEach { $0.mapView = mapView }
+      allMarkers.forEach {
+        let position = $0.position
+        if visibleBounds.hasPoint(position) {
+          $0.mapView = mapView
+        }
+      }
     case .kickBoard:
-      kickBoardMarkers.forEach { $0.mapView = mapView }
+      kickBoardMarkers.forEach {
+        let position = $0.position
+        if visibleBounds.hasPoint(position) {
+          $0.mapView = mapView
+        }
+      }
     case .bike:
-      bikeMarkers.forEach { $0.mapView = mapView }
+      bikeMarkers.forEach {
+        let position = $0.position
+        if visibleBounds.hasPoint(position) {
+          $0.mapView = mapView
+        }
+      }
     case .none:
       break
     }
@@ -708,6 +725,8 @@ extension MapViewController: NMFMapViewCameraDelegate {
       showKickBoardView(kickBoard: kickboard)
       pendingKickBoard = nil
     }
+
+    updateVisibleMarkers()
   }
 }
 

--- a/SSENG/View/MapView/MapViewController.swift
+++ b/SSENG/View/MapView/MapViewController.swift
@@ -510,24 +510,24 @@ extension MapViewController {
 
     switch selected {
     case .all:
-      allMarkers.forEach {
-        let position = $0.position
+      for marker in allMarkers {
+        let position = marker.position
         if visibleBounds.hasPoint(position) {
-          $0.mapView = mapView
+          marker.mapView = mapView
         }
       }
     case .kickBoard:
-      kickBoardMarkers.forEach {
-        let position = $0.position
+      for kickBoardMarker in kickBoardMarkers {
+        let position = kickBoardMarker.position
         if visibleBounds.hasPoint(position) {
-          $0.mapView = mapView
+          kickBoardMarker.mapView = mapView
         }
       }
     case .bike:
-      bikeMarkers.forEach {
-        let position = $0.position
+      for bikeMarker in bikeMarkers {
+        let position = bikeMarker.position
         if visibleBounds.hasPoint(position) {
-          $0.mapView = mapView
+          bikeMarker.mapView = mapView
         }
       }
     case .none:


### PR DESCRIPTION
## 🔗 관련 이슈

- #54 

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 필수 구현에 자기 주변에 킥보드만 보이게 하기 기능은 킥보드 앱에는 너무 의미가 없는 기능인거 같다고 판단하였습니다.
- 이유는 킥보드 쉐어링 앱은 사용자 주변에 있는 킥보드를 찾아야하는데 만약 아예 없다면 걸어다니면서 찾아야하는데 그건 비효율적이라 판단하였습니다.
- 이 요구사항의 의도가 메모리 사용량을 줄인다 라는 의미로 해석하여 더 의미있게 카메라 시야 내에 있는 마커만 화면에 렌더링하여 메모리 효율을 높여줬습니다.

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-19 at 02 34 48](https://github.com/user-attachments/assets/4c1d614f-1baa-4ae2-88a7-806ded49de37)


## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.
