### PR TITLE
✨ Feat: 킥보드 대여 및 반납

### DIFF
--- a/SSENG/CoreData/data/KickboardCoreData/KickboardRepository.swift
+++ b/SSENG/CoreData/data/KickboardCoreData/KickboardRepository.swift
@@ -28,7 +28,7 @@ final class KickboardRepository {
     kb.type = type.rawValue
     kb.registerId = registerId // 유저의 아이디를 넣어주세요
     kb.battery = Int16(Int.random(in: 20 ... 100)) // 배터리 잔량 20~100 사이의 랜덤 값
-    kb.batteryTime = "약 \(round(Double(kb.battery)) * 1.2) 분"
+    kb.batteryTime = String(format: "약 %.1f 분", round(Double(kb.battery) * 1.2))
     kb.isRented = false // 초기 상태는 대여 가능
     // 등록한 유저 아이디
 

--- a/SSENG/CoreData/data/KickboardCoreData/KickboardRepository.swift
+++ b/SSENG/CoreData/data/KickboardCoreData/KickboardRepository.swift
@@ -66,7 +66,7 @@ final class KickboardRepository {
   }
 
   // 킥보드 반납
-  func returnKickboard(id: String, lat: Double, lng: Double, newLocation _: String, detailLocation: String) {
+  func returnKickboard(id: String, lat: Double, lng: Double, detailLocation: String) {
     guard let kb = readKickboard(by: id) else { return }
 
     kb.isRented = false

--- a/SSENG/View/MapView/MapViewController.swift
+++ b/SSENG/View/MapView/MapViewController.swift
@@ -880,7 +880,7 @@ extension MapViewController {
     }
 
     guard let location = locationManager.location else {
-      print("❗️현재 위치 정보를 아직 가져오지 못했어요")
+      print("현재 위치 정보가 없습니다.")
       return
     }
     let lat = location.coordinate.latitude
@@ -893,8 +893,17 @@ extension MapViewController {
       preferredStyle: .alert
     )
 
+    var confirmAction: UIAlertAction? = nil
+
     alert.addTextField { textField in
       textField.placeholder = "예: 건물 앞 자전거 거치대"
+
+      NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification, object: textField, queue: .main) { _ in
+        guard let text = textField.text,
+              let confirm = confirmAction else { return }
+
+        confirm.isEnabled = !text.trimmingCharacters(in: .whitespaces).isEmpty
+      }
     }
 
     // 확인 버튼 클릭시 반납 처리 실행
@@ -915,6 +924,8 @@ extension MapViewController {
       self.riddingButton.backgroundColor = .main
       self.riddingButton.setTitle("대여하기", for: .normal)
     }
+    confirm.isEnabled = false
+    confirmAction = confirm
 
     alert.addAction(confirm)
     alert.addAction(UIAlertAction(title: "취소", style: .cancel))

--- a/SSENG/View/MapView/MapViewController.swift
+++ b/SSENG/View/MapView/MapViewController.swift
@@ -573,11 +573,12 @@ extension MapViewController {
       self.view.layoutIfNeeded()
     }
 
-    // 탑승 중일때 다른 킥보드 대여 못하게
-    riddingButton.isEnabled = false
-    riddingButton.backgroundColor = .lightGray
-    riddingButton.setTitle("기기를 반납 후 이용해주세요.", for: .normal)
-
+    // 탑승 중일때 다른 킥보드 대여 못하게 및 창이 내려간 후에 바뀌게
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      self.riddingButton.isEnabled = false
+      self.riddingButton.backgroundColor = .lightGray
+      self.riddingButton.setTitle("기기를 반납 후 이용해주세요.", for: .normal)
+    }
     // 스톱워치 초기화
     secondsElapsed = 0
     timer?.invalidate() // 혹시 모를 기존 타이머 제거
@@ -904,6 +905,7 @@ extension MapViewController {
       self.kickBoardRepository.returnKickboard(id: self.riddingKickBoard?.id ?? "데이터가 없습니다.", lat: lat, lng: lng, detailLocation: self.detailLocationLabel.text ?? "데이터가 없습니다")
       self.allKickBoardMarker()
       self.hiddenRiddingView()
+      self.locationMove(nowLocation: self.locationManager)
       self.locationManager.stopUpdatingLocation()
       self.mapView.positionMode = .normal
       self.riddingKickBoard = nil


### PR DESCRIPTION
## 🔗 관련 이슈

- #56 

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 킥보드 대여중 UI 구성
- 대여중일때 기기 등록 되지 않게 로직 수정
- 탑승중인 킥보드는 마커 삭제
- 대여중일때 다른 킥보드 대여 할 수 없게 버튼 비활성화 처리(이부분에 대해서 마커를 터치 못하게 처리하게 되면 기기배터리가 없어서 킥보드를 갈아 타야하는데 터치못하게하면 다른 킥보드 정보를 확인할 수 없기때문에 이렇게 처리 했습니다.)
- 대여 시 실시간 타이머 및 과금 UI 표시
- 대여하기 및 반납 버튼을 잘못 누를 수 있기에 알림창을 띄워 한번 더 확인
- 반납 시 상세위치 입력을 해야 확인 버튼을 누를 수 있게
- 반납 위치는 현재 위치를 받아서 현재 위치에 반납
- 배터리 표시 문제는 부동소수점 오차로 인해 1.2가 정확히 표현 되지않아서 오차가 생긴 것을 %.1f로 포맷팅하여 소수점 1자리 까지만 표시되게 하였습니다.

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

<img width="388" height="216" alt="스크린샷 2025-07-19 23 54 01" src="https://github.com/user-attachments/assets/6978b684-5585-47b8-871e-30d0ae6e8410" />

<img width="494" height="936" alt="스크린샷 2025-07-20 00 23 58" src="https://github.com/user-attachments/assets/7b8f63c0-73ec-422c-a404-82ba377079ef" />

<img width="494" height="936" alt="스크린샷 2025-07-20 00 24 15" src="https://github.com/user-attachments/assets/8de52ef2-6853-4739-8522-fa0defeccdb4" />

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-20 at 00 25 12](https://github.com/user-attachments/assets/9771c65d-6bef-4138-9647-b971f81bb44e)

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-20 at 00 25 52](https://github.com/user-attachments/assets/51b558fc-b100-41f5-8357-a08417435a47)

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-20 at 00 26 26](https://github.com/user-attachments/assets/5623d789-f4a5-4f0b-a9db-0fd1c127ed2e)

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.
