### PR TITLE
🚨 Fix: 등록 및 이용 내역 시간 포맷이 초단위로 표시되지 않는 문제 수정

### DIFF
--- a/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
+++ b/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
@@ -106,36 +106,41 @@ class KickboardHistoryCell: UITableViewCell {
       dateLabel.text = dateFormatter.string(from: startTime)
 
       // 시작 시간(startTime)부터 총 이용 시간(duration)을 더해서 종료 시간(endTime) 계산
-      let endTime = startTime.addingTimeInterval(TimeInterval(history.duration * 60))
+      let endTime = startTime.addingTimeInterval(TimeInterval(history.duration))
       /// TimeInterval이 Double랑 동일한 의미인데, 시간 계산 때 의도를 명확하게 하려고 관습적(?)으로 사용한다고 한다.
       /// "이건 시간이야"라는 명확한 의도전달을 위해. Double과 기능적 차이 x
       /// addingTimeInterval(_:)는 Date 타입에 초(second) 단위의 Double값을 더해서 새로운 Date를 반환하는 메서드.
       ///
       /// startTime = 2025-07-18 22:00:00 같은 Date타입.
-      /// duration = 30(분)
+      /// duration = 1800(초)
       /// -> endTime = startTime + 1800초(30분)
       /// -> endTime = 2025-07-18 22:30:00 (자동 계산됨)
 
       let timeFormatter = DateFormatter()
       timeFormatter.locale = Locale(identifier: "ko_KR")
-      timeFormatter.dateFormat = "HH시mm분"
+      timeFormatter.dateFormat = "HH시mm분ss초"
 
       let timeRange = "\(timeFormatter.string(from: startTime)) ~ \(timeFormatter.string(from: endTime))" // "22시02분 ~ 22시43분" 형태로 생셩
 
-      let durationHour = history.duration / 60 // 시간 분리 (90 / 60 -> 1시간)
-      let durationMin = history.duration % 60 // 분 분리 (90 % 60 -> 30분)
+      let rideDuration = history.duration // 초 단위 (3665초)
+      let rideHour = rideDuration / 3600
+      let rideMin = (rideDuration % 3600) / 60
+      let rideSec = rideDuration % 60
 
-      // 시간, 분 조합해서 "1시간" or "35분" or "1시간 35분" 이런 형식으로 사용
-      let durationString: String
-      if durationMin == 0 {
-        durationString = "\(durationHour)시간"
-      } else if durationHour == 0 {
-        durationString = "\(durationMin)분"
-      } else {
-        durationString = "(\(durationHour)시간 \(durationMin)분)"
+      var totalDurations: [String] = []
+      if rideHour > 0 {
+        totalDurations.append("\(rideHour)시간")
+      }
+      if rideMin > 0 {
+        totalDurations.append("\(rideMin)분")
+      }
+      if rideSec > 0 {
+        totalDurations.append("\(rideSec)초")
       }
 
-      // 최종!! "22시02분 ~ 22시43분 (41분)" 으로 표시됨!!
+      let durationString = totalDurations.joined(separator: " ")
+
+      // 최종!! "22시00분00초 ~ 23시01분05초 (1시간1분5초)" 으로 표시됨!!
       timeRangeLabel.text = "\(timeRange) (\(durationString))"
     }
   }

--- a/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
+++ b/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
@@ -118,7 +118,7 @@ class KickboardHistoryCell: UITableViewCell {
 
       let timeFormatter = DateFormatter()
       timeFormatter.locale = Locale(identifier: "ko_KR")
-      timeFormatter.dateFormat = "HH시mm분ss초"
+      timeFormatter.dateFormat = "HH시 mm분 ss초"
 
       let timeRange = "\(timeFormatter.string(from: startTime)) ~ \(timeFormatter.string(from: endTime))" // "22시02분 ~ 22시43분" 형태로 생셩
 

--- a/SSENG/View/MypageView/Cell/KickboardRegisterCell.swift
+++ b/SSENG/View/MypageView/Cell/KickboardRegisterCell.swift
@@ -97,7 +97,7 @@ class KickboardRegisterCell: UITableViewCell {
     dateFormatter.dateFormat = "yyyy년 MM월 dd일"
 
     let timeFormatter = DateFormatter()
-    timeFormatter.dateFormat = "HH시 mm분"
+    timeFormatter.dateFormat = "HH시 mm분 ss초"
 
     if let registerDateStr = kickboard.registerDate,
        let registerDate = registerDateStr.toDate()


### PR DESCRIPTION
## 🔗 관련 이슈

- #62 

## 🛠️ 작업 내용
- KickboardRegisterCell에서 등록 시간 포맷을 `"HH시 mm분 ss초"` 형식으로 변경하여 초 단위까지 표시되도록 수정
- KickboardHistoryCell에서도 동일한 시간 포맷을 적용하여 탑승 시간과 종료 시간을 초 단위까지 동일하게 출력
- 두 셀 간 시간 포맷의 통일을 통해 UI 일관성과 가독성을 개선

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷

## 💬 기타 참고사항
