### PR TITLE
자동로그인 방식 변경, 회원가입, 로그인 페이지 수정 #24, #35

### DIFF
--- a/SSENG/Application/SceneDelegate.swift
+++ b/SSENG/Application/SceneDelegate.swift
@@ -14,7 +14,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = (scene as? UIWindowScene) else { return }
 
     window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = UINavigationController(rootViewController: LoginViewController()) // 시작 뷰컨트롤러 지정
+
+    let rootVC: UIViewController
+    let loggedInID = UserDefaults.standard.string(forKey: "loggedUserID")
+    let isAutoLogin = UserDefaults.standard.bool(forKey: "isAutoLogin")
+
+    if isAutoLogin, loggedInID != nil {
+      rootVC = MapViewController()
+    } else {
+      rootVC = LoginViewController()
+    }
+
+    let navController = UINavigationController(rootViewController: rootVC)
+
+    window?.rootViewController = navController
     window?.makeKeyAndVisible()
   }
 

--- a/SSENG/Application/SceneDelegate.swift
+++ b/SSENG/Application/SceneDelegate.swift
@@ -16,10 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window = UIWindow(windowScene: windowScene)
 
     let rootVC: UIViewController
-    let loggedInID = UserDefaults.standard.string(forKey: "loggedUserID")
+    let loggedUserID = UserDefaults.standard.string(forKey: "loggedUserID")
     let isAutoLogin = UserDefaults.standard.bool(forKey: "isAutoLogin")
 
-    if isAutoLogin, loggedInID != nil {
+    if isAutoLogin == true && loggedUserID != nil {
       rootVC = MapViewController()
     } else {
       rootVC = LoginViewController()

--- a/SSENG/View/LoginView/LoginViewController.swift
+++ b/SSENG/View/LoginView/LoginViewController.swift
@@ -213,8 +213,7 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate, UIT
     } else {
       UserDefaults.standard.set(false, forKey: "isAutoLogin")
     }
-    UserDefaults.standard.set(id, forKey: "autoLoginID")
-
+    UserDefaults.standard.set(id, forKey: "loggedUserID")
   }
 
   private func updateLoginButtonState() {

--- a/SSENG/View/LoginView/LoginViewController.swift
+++ b/SSENG/View/LoginView/LoginViewController.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 //
 //  ViewController.swift
 //  SSENG
@@ -8,7 +9,7 @@ import SnapKit
 import Then
 import UIKit
 
-class LoginViewController: UIViewController, UINavigationControllerDelegate {
+class LoginViewController: UIViewController, UINavigationControllerDelegate, UITextFieldDelegate {
   private var isAgreed = false
   private let repository = UserRepository()
 
@@ -23,7 +24,7 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
   }
 
   private let idTextField = UITextField().then {
-    $0.placeholder = "아이디를 입력하세요."
+    $0.placeholder = "영어/숫자 4-16자"
     $0.keyboardType = .asciiCapable
     $0.textContentType = .none
     $0.autocorrectionType = .no
@@ -32,6 +33,7 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
     $0.autocapitalizationType = .none
     $0.clearButtonMode = .always
     $0.returnKeyType = .next
+    $0.addLeftPadding()
   }
 
   private let idStackView = UIStackView().then {
@@ -45,11 +47,12 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
   }
 
   private let pwTextField = UITextField().then {
-    $0.placeholder = "비밀번호를 입력하세요."
+    $0.placeholder = "영어/숫자/기호 8-32자"
     $0.textContentType = .password
     $0.clearButtonMode = .always
     $0.isSecureTextEntry = true
-    $0.returnKeyType = .next
+    $0.returnKeyType = .done
+    $0.addLeftPadding()
   }
 
   private let autoLoginAgreeCheckBox = UIButton(type: .custom).then {
@@ -96,42 +99,41 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     animateContentAppearance()
+    updateLoginButtonState()
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
     navigationController?.delegate = self
     view.backgroundColor = .systemBackground
-    if UserDefaults.standard.string(forKey: "loggedUserID") != nil {
-      let mapVC = MapViewController()
-      navigationController?.pushViewController(mapVC, animated: true)
-    } else {
-      setupUI()
-      setupConstraints()
-      setupBUttonActions()
-      updateLoginButtonState()
-      addTextFieldObsevers()
-      dismissKeyboardController()
-    }
+
+    setupUI()
+    setupConstraints()
+    setupButtonActions()
+    addTextFieldObsevers()
+    updateLoginButtonState()
+    dismissKeyboardController()
+
+    [idTextField, pwTextField].forEach { $0.delegate = self }
   }
 
   func setupUI() {
-    for item in [
+    [
       appLogoImageView, idStackView, pwStackView, autoLoginStackView, loginButton, signUpBUtton, debugButton,
-    ] {
-      view.addSubview(item)
+    ].forEach {
+      view.addSubview($0)
     }
 
-    for item in [idLabel, idTextField] {
-      idStackView.addArrangedSubview(item)
+    [idLabel, idTextField].forEach {
+      idStackView.addArrangedSubview($0)
     }
 
-    for item in [pwLabel, pwTextField] {
-      pwStackView.addArrangedSubview(item)
+    [pwLabel, pwTextField].forEach {
+      pwStackView.addArrangedSubview($0)
     }
 
-    for item in [autoLoginAgreeCheckBox, autoLoginAgreeLabel] {
-      autoLoginStackView.addArrangedSubview(item)
+    [autoLoginAgreeCheckBox, autoLoginAgreeLabel].forEach {
+      autoLoginStackView.addArrangedSubview($0)
     }
   }
 
@@ -192,7 +194,7 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
     }
   }
 
-  private func setupBUttonActions() {
+  private func setupButtonActions() {
     loginButton.addTarget(self, action: #selector(didTapLogin), for: .touchUpInside)
     signUpBUtton.addTarget(self, action: #selector(didTapSignUp), for: .touchUpInside)
     debugButton.addTarget(self, action: #selector(donttouchthis), for: .touchUpInside)
@@ -200,9 +202,19 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
   }
 
   private func addTextFieldObsevers() {
-    for item in [idTextField, pwTextField] {
-      item.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
+    [idTextField, pwTextField].forEach {
+      $0.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
     }
+  }
+
+  func createDefaultUser(id: String) {
+    if isAgreed {
+      UserDefaults.standard.set(true, forKey: "isAutoLogin")
+    } else {
+      UserDefaults.standard.set(false, forKey: "isAutoLogin")
+    }
+    UserDefaults.standard.set(id, forKey: "autoLoginID")
+
   }
 
   private func updateLoginButtonState() {
@@ -214,15 +226,7 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
     loginButton.alpha = allVAlid ? 1.0 : 0.5
   }
 
-  func createDefaultUser(id: String) {
-    if isAgreed {
-      if UserDefaults.standard.string(forKey: "loggedUserID") == nil {
-        UserDefaults.standard.set(id, forKey: "loggedUserID")
-        return
-      }
-    }
-  }
-
+  // 정규표현식 및 글자수 제한
   func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String)
     -> Bool
   {
@@ -267,16 +271,46 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
     return nil
   }
 
+  func prepareForTransition() {
+    [idStackView, pwStackView, autoLoginStackView, loginButton, signUpBUtton].forEach {
+      $0.alpha = 0
+    }
+  }
+
   func dismissKeyboardController() {
     let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
     tapGesture.cancelsTouchesInView = false
     view.addGestureRecognizer(tapGesture)
   }
 
-  func prepareForTransition() {
-    [idStackView, pwStackView, autoLoginStackView, loginButton, signUpBUtton].forEach {
-      $0.alpha = 0
+  func textFieldDidBeginEditing(_ textField: UITextField) {
+    textField.borderStyle = .roundedRect
+    textField.layer.borderColor = UIColor.main.cgColor
+    textField.layer.cornerRadius = 3.0
+    textField.layer.borderWidth = 1.0
+  }
+
+  func textFieldDidEndEditing(_ textField: UITextField) {
+    textField.borderStyle = .none
+    textField.backgroundColor = .clear
+    textField.layer.borderColor = UIColor.clear.cgColor
+  }
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    guard let text = textField.text, !text.isEmpty else {
+      textField.shake()
+      AudioServicesPlaySystemSound(4095)
+      return false
     }
+    switch textField {
+    case idTextField:
+      pwTextField.becomeFirstResponder()
+    case pwTextField:
+      pwTextField.resignFirstResponder()
+    default:
+      break
+    }
+    return false
   }
 
   func animateContentAppearance() {
@@ -310,10 +344,12 @@ class LoginViewController: UIViewController, UINavigationControllerDelegate {
 
   @objc func didTapLogin() {
     if repository.readUser(by: idTextField.text ?? "id-xxxx")?.id != idTextField.text {
+      idTextField.becomeFirstResponder()
       alertController(on: self, title: "아이디 오류", message: "해당 아이디가 존재하지 않습니다.")
     }
 
     if repository.readUser(by: idTextField.text ?? "pw-xxxx")?.password != pwTextField.text {
+      pwTextField.becomeFirstResponder()
       alertController(on: self, title: "비밀번호 오류", message: "비밀번호가 일치하지 않습니다.")
     }
 

--- a/SSENG/View/SignView/SignViewController.swift
+++ b/SSENG/View/SignView/SignViewController.swift
@@ -369,8 +369,8 @@ class SignViewController: UIViewController, UITextFieldDelegate {
   }
   
   func textFieldDidEndEditing(_ textField: UITextField) {
-    textField.backgroundColor = .clear
     textField.borderStyle = .none
+    textField.backgroundColor = .clear
     textField.layer.borderColor = UIColor.clear.cgColor
   }
   
@@ -447,7 +447,6 @@ class SignViewController: UIViewController, UITextFieldDelegate {
   }
 
   @objc func didTapSubmitButton(_: UIButton) {
-    // TODO: 2. 빈 칸(변경 필요한 칸) 파악되면 하이라이팅
     // TODO: 3. userDefault에 넣어서 로그인 창에 정보 미리 넣거나 바로 로그인하게 만들기
     let id = idTextField.text ?? ""
     let pw = pwTextField.text ?? ""
@@ -456,32 +455,39 @@ class SignViewController: UIViewController, UITextFieldDelegate {
 
     // 입력 잘못된 칸 Alert
     if !isValidID(id) {
+      idTextField.becomeFirstResponder()
       alertController(on: self, title: "아이디 오류", message: "아이디는 4-16자 영문 소문자와 숫자로만 구성되어야 합니다.")
       return
     }
     
     if repository.readUser(by: idTextField.text ?? "id-xxxx") != nil {
+      idTextField.becomeFirstResponder()
       alertController(on: self, title: "아이디 중복", message: "중복된 아이디입니다.\n다른 아이디를 사용해 주세요.")
       return
     }
 
     if !isValidPW(pw) {
+      pwTextField.becomeFirstResponder()
       alertController(on: self, title: "패스워드 오류", message: "비밀번호는 8-32자 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
       return
     }
 
     if pw != rePw {
+      pwTextField.becomeFirstResponder()
       alertController(on: self, title: "패스워드 재확인 오류", message: "패스워드가 같지 않습니다.")
       return
     }
 
     if !isValidName(name) {
+      nameTextField.becomeFirstResponder()
       alertController(on: self, title: "닉네임 오류", message: "잘못된 닉네임입니다.")
       return
     }
 
     if repository.readName(by: nameTextField.text ?? "name-xxxx") != nil {
+      nameTextField.becomeFirstResponder()
       alertController(on: self, title: "닉네임 중복", message: "중복된 닉네임입니다.\n다른 아이디를 사용해 주세요.")
+      
       return
     }
 
@@ -563,3 +569,4 @@ extension UITextField {
     self.leftViewMode = .always
   }
 }
+


### PR DESCRIPTION
## 🔗 관련 이슈

- #24, #35

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 자동로그인이 아닐 때 마이페이지 불러올 수 없는 버그 수정
- 회원가입 페이지에서 잘못된이 있으면 그 위치로 보내는 기능 추가
- 회원가입에 들어갔던 기능들 로그인 페이지에도 추가

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [ ] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.
유저 디폴트에 들어간 유저 아이디는 `loggedUserID`로 유지 됐고, `isAutoLogin`를 추가했습니다. 로그아웃할 때 이 두 개 지워주시면 됩니다.