### PR TITLE
✨ Feat: 마이페이지 이용한 킥보드 신고 기능 구현

### DIFF
--- a/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
+++ b/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
@@ -9,8 +9,14 @@ import SnapKit
 import Then
 import UIKit
 
+protocol KickboardHistoryCellDelegate: AnyObject {
+  func didTapReportButton(_ cell: KickboardHistoryCell)
+}
+
 class KickboardHistoryCell: UITableViewCell {
   static let identifier = "KickboardHistoryCell"
+
+  weak var delegate: KickboardHistoryCellDelegate?
 
   private let containerView = UIView()
 
@@ -28,6 +34,11 @@ class KickboardHistoryCell: UITableViewCell {
     $0.font = .systemFont(ofSize: 13)
     $0.textColor = .secondaryLabel
     $0.numberOfLines = 0
+  }
+
+  private let reportButton = UIButton().then {
+    $0.setImage(UIImage(systemName: "exclamationmark.triangle"), for: .normal)
+    $0.tintColor = .systemRed
   }
 
   private lazy var stackView = UIStackView(arrangedSubviews: [dateLabel, timeRangeLabel]).then {
@@ -61,7 +72,8 @@ class KickboardHistoryCell: UITableViewCell {
     selectionStyle = .none
 
     contentView.addSubview(containerView)
-    [kickboardImageView, stackView].forEach { containerView.addSubview($0) }
+    [kickboardImageView, stackView, reportButton].forEach { containerView.addSubview($0) }
+    reportButton.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
   }
 
   // MARK: - configureLayout
@@ -86,6 +98,11 @@ class KickboardHistoryCell: UITableViewCell {
       $0.centerY.equalToSuperview()
       $0.leading.equalTo(kickboardImageView.snp.trailing).offset(12)
       $0.trailing.equalToSuperview().offset(-16)
+    }
+
+    reportButton.snp.makeConstraints {
+      $0.trailing.equalToSuperview().inset(16)
+      $0.bottom.equalToSuperview().inset(8)
     }
   }
 
@@ -143,5 +160,9 @@ class KickboardHistoryCell: UITableViewCell {
       // 최종!! "22시00분00초 ~ 23시01분05초 (1시간1분5초)" 으로 표시됨!!
       timeRangeLabel.text = "\(timeRange) (\(durationString))"
     }
+  }
+
+  @objc private func reportButtonTapped() {
+    delegate?.didTapReportButton(self)
   }
 }

--- a/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
+++ b/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
@@ -16,7 +16,7 @@ protocol KickboardHistoryCellDelegate: AnyObject {
 class KickboardHistoryCell: UITableViewCell {
   static let identifier = "KickboardHistoryCell"
 
-  weak var delegate: KickboardHistoryCellDelegate?
+  weak var delegate: KickboardHistoryCellDelegate? // TableView가 Cell을 강한참조해서 weak
 
   private let containerView = UIView()
 

--- a/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
+++ b/SSENG/View/MypageView/Cell/KickboardHistoryCell.swift
@@ -37,7 +37,7 @@ class KickboardHistoryCell: UITableViewCell {
   }
 
   private let reportButton = UIButton().then {
-    $0.setImage(UIImage(systemName: "exclamationmark.triangle"), for: .normal)
+    $0.setImage(UIImage(systemName: "exclamationmark.bubble"), for: .normal)
     $0.tintColor = .systemRed
   }
 
@@ -102,7 +102,7 @@ class KickboardHistoryCell: UITableViewCell {
 
     reportButton.snp.makeConstraints {
       $0.trailing.equalToSuperview().inset(16)
-      $0.bottom.equalToSuperview().inset(8)
+      $0.top.equalToSuperview().inset(8)
     }
   }
 

--- a/SSENG/View/MypageView/MypageViewController.swift
+++ b/SSENG/View/MypageView/MypageViewController.swift
@@ -252,10 +252,28 @@ extension MypageViewController: UITableViewDataSource {
       }
       let history = histories[indexPath.row]
       cell.configure(history)
+      cell.delegate = self
       return cell
 
     default:
       return UITableViewCell()
     }
+  }
+}
+
+extension MypageViewController: KickboardHistoryCellDelegate {
+  func didTapReportButton(_: KickboardHistoryCell) {
+    let alert = UIAlertController(title: "문제 신고", message: "문제 내용을 입력해주세요.", preferredStyle: .alert)
+    alert.addTextField { $0.placeholder = "예: 고장/침수/잠금 해제 불가" }
+
+    let submitAction = UIAlertAction(title: "확인", style: .default) { _ in
+      let confirm = UIAlertController(title: "신고 완료", message: "신고가 접수되었습니다.", preferredStyle: .alert)
+      confirm.addAction(UIAlertAction(title: "확인", style: .default))
+      self.present(confirm, animated: true)
+    }
+
+    alert.addAction(submitAction)
+    alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+    present(alert, animated: true)
   }
 }

--- a/SSENG/View/MypageView/MypageViewController.swift
+++ b/SSENG/View/MypageView/MypageViewController.swift
@@ -273,7 +273,7 @@ extension MypageViewController: KickboardHistoryCellDelegate {
     }
 
     alert.addAction(submitAction)
-    alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+    alert.addAction(UIAlertAction(title: "취소", style: .destructive))
     present(alert, animated: true)
   }
 }

--- a/SSENG/View/MypageView/MypageViewController.swift
+++ b/SSENG/View/MypageView/MypageViewController.swift
@@ -266,14 +266,20 @@ extension MypageViewController: KickboardHistoryCellDelegate {
     let alert = UIAlertController(title: "문제 신고", message: "문제 내용을 입력해주세요.", preferredStyle: .alert)
     alert.addTextField { $0.placeholder = "예: 고장/침수/잠금 해제 불가" }
 
-    let submitAction = UIAlertAction(title: "확인", style: .default) { _ in
-      let confirm = UIAlertController(title: "신고 완료", message: "신고가 접수되었습니다.", preferredStyle: .alert)
-      confirm.addAction(UIAlertAction(title: "확인", style: .default))
-      self.present(confirm, animated: true)
+    let submitAction = UIAlertAction(title: "신고하기", style: .destructive) { _ in
+      if let text = alert.textFields?.first?.text, text.trimmingCharacters(in: .whitespaces).count >= 2 { // 2글자 이상 입력된 경우만
+        let confirm = UIAlertController(title: "신고 완료", message: "신고가 접수되었습니다.", preferredStyle: .alert)
+        confirm.addAction(UIAlertAction(title: "확인", style: .default))
+        self.present(confirm, animated: true)
+      } else { // 2글자 이하로 입력한 경우 Alert
+        let error = UIAlertController(title: "오류", message: "2글자 이상 입력해주세요.", preferredStyle: .alert)
+        error.addAction(UIAlertAction(title: "확인", style: .default))
+        self.present(error, animated: true)
+      }
     }
 
     alert.addAction(submitAction)
-    alert.addAction(UIAlertAction(title: "취소", style: .destructive))
+    alert.addAction(UIAlertAction(title: "취소", style: .cancel))
     present(alert, animated: true)
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #79 

## 🛠️ 작업 내용
- 킥보드 이용내역 셀에 **삭제 버튼 추가**
- 버튼 위치를 오른쪽 상단에 위치시키고, SF 심볼 `exclamationmark.bubble` 적용
- 버튼 탭 시 Alert으로 신고 내용을 입력받도록 구성
- "신고하기" 버튼은 `.destructive` 스타일로 강조 (빨간색)
- 입력값이 **2글자 이상일 경우에만 신고 가능**
- 입력 기준 미달 시 오류 메시지 Alert 출력
- 취소 버튼은 `.cancel` 스타일로 적용되어 **왼쪽에 파란색**으로 표시됨 (시스템 규칙에 따름)

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/834f0d34-01d3-46b0-845c-ae3225019b58" width="300" />

## 💬 기타 참고사항

