### PR TITLE
✨: 마이페이지 섹션 접힘 상태 저장 및 킥보드 개수 표시

### DIFF
--- a/SSENG/View/MypageView/MypageViewController.swift
+++ b/SSENG/View/MypageView/MypageViewController.swift
@@ -19,7 +19,7 @@ class MypageViewController: UIViewController {
   }
 
   private var section1ToggleButton: UIButton?
-  private var isKickboardSectionExpanded = true // 나중에 삭제 예정
+  private var isKickboardSectionExpanded = false
 
   private var user: User? // CoreData에서 가져온 유저 정보
   private let userRepository = UserRepository() // User 정보 가져올 때 사용
@@ -170,9 +170,12 @@ extension MypageViewController: UITableViewDataSource {
 
   // 각 섹션에 맞는 헤더 타이틀 설정
   func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    let registeredCount = kickboards.count
+    // 팀원과 상의하여 "등록한 킥보드"는 개수까지, "킥보드 이용 내역"은 개수를 제거하기로 결정
+
     let title: String
     switch section {
-    case 1: title = "등록한 킥보드"
+    case 1: title = "등록한 킥보드 (\(registeredCount)개)"
     case 2: title = "킥보드 이용 내역"
     default: return nil
     }
@@ -260,6 +263,8 @@ extension MypageViewController: UITableViewDataSource {
     }
   }
 }
+
+// MARK: - 킥보드 상태 이상 신고 Alert
 
 extension MypageViewController: KickboardHistoryCellDelegate {
   func didTapReportButton(_: KickboardHistoryCell) {

--- a/SSENG/View/MypageView/MypageViewController.swift
+++ b/SSENG/View/MypageView/MypageViewController.swift
@@ -42,6 +42,7 @@ class MypageViewController: UIViewController {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    isKickboardSectionExpanded = UserDefaults.standard.bool(forKey: "isKickboardSectionExpanded")
     fetchUserData()
     fetchKickboardData()
     fetchHistoryData()
@@ -113,6 +114,7 @@ class MypageViewController: UIViewController {
   // 등록한 킥보드 섹션을 열거나 접는 동작
   @objc private func toggleSection() {
     isKickboardSectionExpanded.toggle() // 확장 상태 토글
+    UserDefaults.standard.set(isKickboardSectionExpanded, forKey: "isKickboardSectionExpanded")
 
     let indexPaths = (0 ..< kickboardsCount).map { IndexPath(row: $0, section: 1) } // 현재 섹션의 셀 위치들을 미리 만듦
     if isKickboardSectionExpanded {


### PR DESCRIPTION
## 🔗 관련 이슈

- #84

## 🛠️ 작업 내용
- 마이페이지의 "등록한 킥보드"섹션을 기본 접힘 상태로 설정
- viewForHeaderInSection에서 킥보드 개수를 동적으로 표시
- toggleSection()에서 접힘/펼침 상태를 UserDefaults로 저장
- viewWillAppear()에서 저장된 상태를 불러와 UI에 반영

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/488821ba-83ff-4854-b3a8-8ccf9c78da19" width="300" />

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.
