### PR TITLE
✨: SplashViewController 추가 및 런치 스크린 구현 #86

### DIFF
--- a/SSENG/Application/SceneDelegate.swift
+++ b/SSENG/Application/SceneDelegate.swift
@@ -15,16 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     window = UIWindow(windowScene: windowScene)
 
-    let rootVC: UIViewController
-    let loggedUserID = UserDefaults.standard.string(forKey: "loggedUserID")
-    let isAutoLogin = UserDefaults.standard.bool(forKey: "isAutoLogin")
-
-    if isAutoLogin == true, loggedUserID != nil {
-      rootVC = MapViewController()
-    } else {
-      rootVC = LoginViewController()
-    }
-
+    let rootVC = SplashViewController()
     let navController = UINavigationController(rootViewController: rootVC)
 
     window?.rootViewController = navController

--- a/SSENG/View/SplashView/SplashViewController.swift
+++ b/SSENG/View/SplashView/SplashViewController.swift
@@ -1,0 +1,43 @@
+//
+//  SplashViewController.swift
+//  SSENG
+//
+//  Created by 서광용 on 7/21/25.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+class SplashViewController: UIViewController {
+  private let logoImageView = UIImageView().then {
+    $0.image = UIImage(named: "Logo")
+    $0.contentMode = .scaleAspectFit
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .white
+
+    view.addSubview(logoImageView)
+    logoImageView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.width.height.equalTo(150)
+    }
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+      self.moveToNextScreen()
+    }
+  }
+
+  private func moveToNextScreen() {
+    let loggedUserID = UserDefaults.standard.string(forKey: "loggedUserID")
+    let isAutoLogin = UserDefaults.standard.bool(forKey: "isAutoLogin")
+
+    let nextVC: UIViewController = (isAutoLogin && loggedUserID != nil) ? MapViewController() : LoginViewController()
+
+    let nav = UINavigationController(rootViewController: nextVC)
+    guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+    sceneDelegate.window?.rootViewController = nav
+  }
+}


### PR DESCRIPTION

## 🔗 관련 이슈

- #86 

## 🛠️ 작업 내용
- LaunchScreen 이후에 표시될 SplashViewController 추가
- 앱 시작 시 Splash에서 앱 로고 2초간 표시 후 자동 로그인 여부에 따라 분기
- SceneDelegate에서 SplashViewController를 루트로 설정하도록 변경

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/21cdccba-d052-4970-8e25-353b74325e53" width="300"/>

## 💬 기타 참고사항
- iOS의 LaunchScreen은 정적인 화면으로, 코드 실행(조건 분기, 타이머 등)이 불가능 하다고 확인했습니다.
- 그래서 앱 실행 시 일정 시간동안 로고 표시를 하기 위해서 `SplashViewController`를 별도로 만들어 주었습니다.
- [참고 블로그](https://yy-dev.tistory.com/136)
